### PR TITLE
Add select aliases

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,14 +17,14 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
-        # - repo: https://github.com/pre-commit/mirrors-mypy
-        # rev: v0.931
-        # hooks:
-        # - id: mypy
-        # args: ['--ignore-missing-imports', '--disable-error-code', 'name-defined']
+  # - repo: https://github.com/pre-commit/mirrors-mypy
+  #   rev: v0.931
+  #   hooks:
+  #     - id: mypy
+  #       args: ['--ignore-missing-imports', '--disable-error-code', 'name-defined']
   - repo: https://github.com/PyCQA/flake8
     rev: 4.0.1
     hooks:

--- a/pyprql/lang/prql.lark
+++ b/pyprql/lang/prql.lark
@@ -47,7 +47,7 @@
     select_fields: ("[" select_field ("," select_field)*  "]" )* \
                    (name*)
 
-    select_field: name ( "|" "as" name )?
+    select_field: [alias] name ( "|" "as" name )?
     derive: ("derive" \
             ( "[" derive_line+ "]" | derive_line ))+
     derive_line: name ":" derive_body (",")?

--- a/pyprql/lang/prql.py
+++ b/pyprql/lang/prql.py
@@ -624,12 +624,15 @@ class SelectField(_Ast):
 
     Parameters
     ----------
+    alias : Optional[Alias]
+        The alias for the column in the select.
     name : Name
         The column to be selected.
     cast_type : Optional[Name]
         Whether the column should be cast as a new name.
     """
 
+    alias: Optional[Alias]
     name: Name
     cast_type: Optional[Name] = None
 
@@ -641,9 +644,15 @@ class SelectField(_Ast):
         str
             The SelectFiled representation.
         """
+        result = str(self.name)
+
         if self.cast_type is not None:
-            return f"CAST({self.name} as {self.cast_type})"
-        return str(self.name)
+            result = f"CAST({result} as {self.cast_type})"
+
+        if self.alias is not None:
+            result += f" as {self.alias}"
+
+        return result
 
 
 @dataclass()

--- a/tests/test_sql_generator.py
+++ b/tests/test_sql_generator.py
@@ -470,7 +470,8 @@ class TestSqlGenerator(unittest.TestCase):
         q = """
         from even_longer_foo:foo
         derive [
-            val: foo.some_value,
+            val: foo.some_value
+        select [
             other_val: even_longer_foo.other_value
         ]
         """

--- a/tests/test_sql_generator.py
+++ b/tests/test_sql_generator.py
@@ -470,8 +470,24 @@ class TestSqlGenerator(unittest.TestCase):
         q = """
         from even_longer_foo:foo
         derive [
-            val: foo.some_value
+            val: foo.some_value,
+            other_val: even_longer_foo.other_value
+        ]
+        """
+        print(q)
+        res = prql.to_sql(q)
+        # print(res)
+        assert res.index("even_longer_foo.some_value as val") != -1
+        assert res.index("even_longer_foo.other_value as other_val") != -1
+
+    # print(res)
+
+    def test_select_alias(self):
+        """Alias, even when given ridiculous aliases."""
+        q = """
+        from even_longer_foo:foo
         select [
+            val: foo.some_value,
             other_val: even_longer_foo.other_value
         ]
         """


### PR DESCRIPTION
In the live editor the prql
```
from employees
filter country = "USA"                           # Each line transforms the previous result.
select [                                         # This adds columns / variables.
  s: salary
]
```

generates the SQL
```sql
SELECT
  salary AS s
FROM
  employees
WHERE
  country = 'USA'
```

*****

In pyprql it fails