### PR TITLE
feat: prepare for next release (based on prql-python 0.6.0)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: "chore: "

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,12 +6,6 @@ on:
     branches:
       - main
 
-  workflow_dispatch:
-
-env:
-  POETRY_VERSION: 1.3.0
-  CACHE_NUMBER: 6
-
 jobs:
   release:
     # Run if we have a label `release` on a merged PR
@@ -22,26 +16,14 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.9
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-        with:
-          version: ${{ inputs.poetry_version }}
-      - name: Cache Pip
-        uses: actions/cache@v3
-        with:
-          path: ~/.pip
-          key: pip${{ inputs.cache_number }}-PT${{ inputs.poetry_version }}
-      - run: poetry install
+
       - name: Configure git
         run: |
           git config --global user.name 'GitHub Actions'
           git config --global user.email 'gha@prql-lang.org'
+
       - name: Python Semantic Release
-        uses: relekang/python-semantic-release@master
+        uses: python-semantic-release/python-semantic-release@v7.33.2
         with:
           github_token: ${{ secrets.PRQL_BOT_GH_TOKEN }}
           repository_username: __token__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ license = "Apache-2.0"
 name = "pyprql"
 readme = "README.md"
 repository = "https://github.com/prql/pyprql"
-version = "0.5.14"
+version = "0.5.13"
 
 [tool.poetry.dependencies]
 python = "^3.8"


### PR DESCRIPTION
Based on the discussion on #140, preparing for the next release.

A little research shows that python-semantic-release is used in the following repository and will probably work.......
https://github.com/python-gitlab/python-gitlab/blob/d387d91401fdf933b1832ea2593614ea6b7d8acf/.github/workflows/release.yml