### PR TITLE
ci: allow release workflow run by hand

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   release:
-    # Run if we have a label `release` on a merged PR
+    # Run if we have a label `release` on a merged PR or it's run manually
     if: (github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'pr-release')) || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,11 +5,12 @@ on:
       - closed
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   release:
     # Run if we have a label `release` on a merged PR
-    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'pr-release')
+    if: (github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'pr-release')) || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
While PR-based releases are convenient, but manual triggering is also useful.