### PR TITLE
ci: Dependabot on minor versions only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,7 @@ updates:
       interval: daily
     commit-message:
       prefix: "chore: "
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-patch


### PR DESCRIPTION
This should reduce the dependabot noise. We can always do `poetry lock` ourselves for a full dependency upgrade on all patch versions
