### PR TITLE
ci: fix release workflow for Python Semantic Release v8

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,8 @@ jobs:
   release:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -33,9 +35,12 @@ jobs:
           git config --global user.email 'gha@prql-lang.org'
 
       - name: Python Semantic Release
+        id: release
         env:
           GH_TOKEN: ${{ secrets.PRQL_BOT_GH_TOKEN }}
-          REPOSITORY_USERNAME: __token__
-          REPOSITORY_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: |
-          poetry run semantic-release -v DEBUG publish
+          poetry run semantic-release --verbose publish
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        if: steps.release.outputs.released == 'true'


### PR DESCRIPTION
> Python Semantic Release no longer uploads distributions to PyPI - see [Repurposing of version and publish commands](https://python-semantic-release.readthedocs.io/en/latest/migrating_from_v7.html#breaking-commands-repurposed-version-and-publish). If you are using Python Semantic Release to publish release notes and artefacts to GitHub releases, there is a new GitHub Action [upload-to-gh-release](https://github.com/python-semantic-release/upload-to-gh-release) which will perform this action for you.