### PR TITLE
feat: `prql` namespace for polars.DataFrame and polars.LazyFrame

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 pyprql contains:
 
 - pyprql.pandas_accessor — Pandas integration for PRQL
+- pyprql.polars_namespace — Polars integration for PRQL
 - pyprql.magic — IPython magic for connecting to databases using `%%prql`
 - pyprql.compile — An export of `prqlc`'s `compile` function
 
@@ -24,6 +25,12 @@ For docs, check out the [pyprql docs](https://pyprql.readthedocs.io/), and the
 pip install pyprql
 ```
 
+Or, install with optional dependencies:
+
+```sh
+pip install pyprql[polars]
+```
+
 ## Usage
 
 ### Pandas integration
@@ -31,6 +38,16 @@ pip install pyprql
 ```python
 import pandas as pd
 import pyprql.pandas_accessor
+
+df = (...)
+results_df = df.prql.query("select {age, name, occupation} | filter age > 21")
+```
+
+### Polars integration
+
+```python
+import polars as pl
+import pyprql.polars_namespace
 
 df = (...)
 results_df = df.prql.query("select {age, name, occupation} | filter age > 21")
@@ -71,7 +88,7 @@ FROM
   artists
 ```
 
-For context, `prqlc` is the Python binding for `prql-compiler`, so only
+For context, `prqlc` in Python is the Python binding for the `prqlc` Rust crate, so only
 contains functions for compilation; and this library offers broader python
 integrations and tooling.
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -3280,4 +3280,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "f2af180d8753aced595d95d2fa75094daebc500297fc64eb6bcc3600b491df14"
+content-hash = "4029f4b64485d9418f520ffd2e5f175d1f51ca28e95cb4b444410f9173ad273e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ major_on_zero = false
 upload_to_pypi = true
 upload_to_release = true
 version_toml = ["pyproject.toml:tool.poetry.version"]
-version_variable = ["pyprql/__init__.py:__version__"]
 
 [tool.pytest.ini_options]
 addopts = """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ jupysql = ">=0.10"
 pandas = ">=1.5"
 prqlc = "^0.11.0"
 traitlets = ">=5"
+polars = { version = ">= 0.20.23", extras = ["polars"] }
 
 [tool.poetry.dev-dependencies]
 Sphinx = "~7.1"
@@ -66,12 +67,8 @@ changelog_file = "CHANGELOG.md"
 major_on_zero = false
 upload_to_pypi = true
 upload_to_release = true
-version_toml = [
-  "pyproject.toml:tool.poetry.version",
-]
-version_variable = [
-  "pyprql/__init__.py:__version__",
-]
+version_toml = ["pyproject.toml:tool.poetry.version"]
+version_variable = ["pyprql/__init__.py:__version__"]
 
 [tool.pytest.ini_options]
 addopts = """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ requires = ["poetry-core>=1.3.0"]
 
 [tool.ruff]
 fix = true
-ignore = [
+lint.ignore = [
   # Line length — black handles
   "E5", #
   # No lambdas — too strict

--- a/pyprql/__init__.py
+++ b/pyprql/__init__.py
@@ -2,5 +2,3 @@
 
 import prqlc  # noqa: F401
 from prqlc import compile  # noqa: F401
-
-__version__ = "0.8.0"

--- a/pyprql/polars_namespace/__init__.py
+++ b/pyprql/polars_namespace/__init__.py
@@ -1,1 +1,1 @@
-from .prql import PrqlSubNamespace  # noqa: F401
+from .prql import PrqlNamespace  # noqa: F401

--- a/pyprql/polars_namespace/__init__.py
+++ b/pyprql/polars_namespace/__init__.py
@@ -1,0 +1,1 @@
+from .prql import PrqlSubNamespace  # noqa: F401

--- a/pyprql/polars_namespace/prql.py
+++ b/pyprql/polars_namespace/prql.py
@@ -2,15 +2,19 @@ import polars as pl
 import prqlc
 
 
+from typing import TypeVar, Generic
+
+
+T_DF = TypeVar("T_DF", pl.DataFrame, pl.LazyFrame)
+
+
 @pl.api.register_dataframe_namespace("prql")
 @pl.api.register_lazyframe_namespace("prql")
-class PrqlNamespace:
-    def __init__(self, df: pl.DataFrame | pl.LazyFrame):
+class PrqlNamespace(Generic[T_DF]):
+    def __init__(self, df: T_DF):
         self._df = df
 
-    def query(
-        self, prql_query: str, *, table_name: str | None = None
-    ) -> pl.DataFrame | pl.LazyFrame:
+    def query(self, prql_query: str, *, table_name: str | None = None) -> T_DF:
         prepended_query: str = f"from self \n {prql_query}"
         sql_query: str = prqlc.compile(
             prepended_query,

--- a/pyprql/polars_namespace/prql.py
+++ b/pyprql/polars_namespace/prql.py
@@ -1,0 +1,21 @@
+import polars as pl
+import prqlc
+
+
+@pl.api.register_dataframe_namespace("prql")
+@pl.api.register_lazyframe_namespace("prql")
+class PrqlSubNamespace:
+    def __init__(self, df: pl.DataFrame | pl.LazyFrame):
+        self._df = df
+
+    def query(
+        self, prql_query: str, *, table_name: str | None = None
+    ) -> pl.DataFrame | pl.LazyFrame:
+        prepended_query: str = f"from self \n {prql_query}"
+        sql_query: str = prqlc.compile(
+            prepended_query,
+            options=prqlc.CompileOptions(
+                target="sql.any", format=False, signature_comment=False
+            ),
+        )
+        return self._df.sql(sql_query, table_name=table_name)

--- a/pyprql/polars_namespace/prql.py
+++ b/pyprql/polars_namespace/prql.py
@@ -4,7 +4,7 @@ import prqlc
 
 @pl.api.register_dataframe_namespace("prql")
 @pl.api.register_lazyframe_namespace("prql")
-class PrqlSubNamespace:
+class PrqlNamespace:
     def __init__(self, df: pl.DataFrame | pl.LazyFrame):
         self._df = df
 

--- a/pyprql/polars_namespace/prql.py
+++ b/pyprql/polars_namespace/prql.py
@@ -1,6 +1,6 @@
+from __future__ import annotations
 import polars as pl
 import prqlc
-
 
 from typing import TypeVar, Generic
 

--- a/pyprql/tests/test_polars_namespace.py
+++ b/pyprql/tests/test_polars_namespace.py
@@ -1,0 +1,29 @@
+import polars as pl
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def import_accessor():
+    import pyprql.polars_namespace  # noqa
+
+
+def test_polars_df_namespace():
+    df = pl.DataFrame({"latitude": [1, 2, 3], "longitude": [1, 2, 3]})
+    res = df.prql.query(
+        "select {latitude, longitude} | filter latitude > 1 | sort latitude"
+    )
+    assert res.to_dict(as_series=False) == {
+        "latitude": [2, 3],
+        "longitude": [2, 3],
+    }
+
+
+def test_polars_lf_namespace():
+    df = pl.LazyFrame({"latitude": [1, 2, 3], "longitude": [1, 2, 3]})
+    res = df.prql.query(
+        "select {latitude, longitude} | filter latitude > 1 | sort latitude"
+    ).collect()
+    assert res.to_dict(as_series=False) == {
+        "latitude": [2, 3],
+        "longitude": [2, 3],
+    }


### PR DESCRIPTION
Close #371

```python
import polars as pl
from datetime import date
from pyprql import polars_namespace

df = pl.DataFrame({
    "a": [1, 2, 3],
    "b": ["zz", "yy", "xx"],
    "c": [date(1999, 12, 31), date(2010, 10, 10), date(2077, 8, 8)],
})

df.prql.query("select {a, b, c_year = s'EXTRACT(year FROM c)'} | filter a > 1")
# shape: (2, 3)
# ┌─────┬─────┬────────┐
# │ a   ┆ b   ┆ c_year │
# │ --- ┆ --- ┆ ---    │
# │ i64 ┆ str ┆ i32    │
# ╞═════╪═════╪════════╡
# │ 2   ┆ yy  ┆ 2010   │
# │ 3   ┆ xx  ┆ 2077   │
# └─────┴─────┴────────┘
```
